### PR TITLE
add depedency testImplementation block for build.gradle.kts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ SpecMock provides Mock Server for various specs, offering a lightweight, fast, a
 ```groovy
 // build.gradle
 testImplementation 'io.specmock:specmock:${specMockVersion}'
+        
+// build.gradle.kts
+testImplementation("io.specmock:specmock:${specMockVersion}")
 
 // pom.xml
 <dependency>


### PR DESCRIPTION
## Motivation
- Can also build gradle with build.gradle.kts
- and [Kotlin DSL is now the Default for New Gradle Builds]( https://blog.jetbrains.com/kotlin/2023/04/kotlin-dsl-is-the-default-for-new-gradle-builds/)

## Modification
- add code snipet for build.gradle.kts in README.md

close #6 