### PR TITLE
Register JavaTimeModule with ObjectMapper for enhanced date/time handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ SpecMock provides Mock Server for various specs, offering a lightweight, fast, a
 [![License](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Twitter](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2FSpecMock)](https://twitter.com/SpecMock)
 
+## Dependency
+
+```groovy
+// build.gradle
+testImplementation 'io.specmock:specmock:${specMockVersion}'
+
+// pom.xml
+<dependency>
+    <groupId>io.specmock</groupId>
+    <artifactId>specmock</artifactId>
+    <version>${specMockVersion}</version>
+</dependency>
+```
+
 ## How to use
 
 ### SpringWebBind

--- a/specmock/build.gradle
+++ b/specmock/build.gradle
@@ -5,4 +5,5 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-starter-web:${property("springBootVersion")}")
     testImplementation("org.springframework.boot:spring-boot-starter-web:${property("springBootVersion")}")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 }

--- a/specmock/src/main/java/io/specmock/core/ArmeriaHttpSpecHandler.java
+++ b/specmock/src/main/java/io/specmock/core/ArmeriaHttpSpecHandler.java
@@ -41,7 +41,8 @@ import io.netty.util.AsciiString;
  * ArmeriaHttpSpecHandler class extends AbstractHttpService to handle HTTP requests based on a given HttpSpec.
  */
 public final class ArmeriaHttpSpecHandler extends AbstractHttpService {
-    private final ObjectMapper mapper = new ObjectMapper().registerModules(new KotlinModule.Builder().build(), new JavaTimeModule());
+    private final ObjectMapper mapper = new ObjectMapper().registerModules(new KotlinModule.Builder().build(),
+                                                                           new JavaTimeModule());
     private final HttpSpec spec;
 
     /**

--- a/specmock/src/main/java/io/specmock/core/ArmeriaHttpSpecHandler.java
+++ b/specmock/src/main/java/io/specmock/core/ArmeriaHttpSpecHandler.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.kotlin.KotlinModule;
 
 import com.linecorp.armeria.common.HttpRequest;
@@ -40,7 +41,7 @@ import io.netty.util.AsciiString;
  * ArmeriaHttpSpecHandler class extends AbstractHttpService to handle HTTP requests based on a given HttpSpec.
  */
 public final class ArmeriaHttpSpecHandler extends AbstractHttpService {
-    private final ObjectMapper mapper = new ObjectMapper().registerModule(new KotlinModule.Builder().build());
+    private final ObjectMapper mapper = new ObjectMapper().registerModules(new KotlinModule.Builder().build(), new JavaTimeModule());
     private final HttpSpec spec;
 
     /**

--- a/specmock/src/test/java/io/specmock/core/ObjectMapperTest.java
+++ b/specmock/src/test/java/io/specmock/core/ObjectMapperTest.java
@@ -1,0 +1,51 @@
+package io.specmock.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ObjectMapperTest {
+
+    private ObjectMapper objectMapper;
+    private String value = "{\"localDateTimeValue\":\"2020-01-01T00:00:00\"}";
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void unsupportedLocalDateTime() {
+        assertThatThrownBy(() -> {
+            objectMapper.readValue(value, LocalDateTimeRequest.class);
+        }).isInstanceOf(InvalidDefinitionException.class);
+    }
+
+    @Test
+    void supportLocalDateTime() throws JsonProcessingException {
+        objectMapper.registerModule(new JavaTimeModule());
+
+        final LocalDateTimeRequest localDateTimeRequest = objectMapper.readValue(value, LocalDateTimeRequest.class);
+
+        final LocalDateTime expected = LocalDateTime.of(2020, 1, 1, 0, 0, 0);
+        assertThat(localDateTimeRequest.getLocalDateTimeValue()).isEqualTo(expected);
+    }
+
+
+    private static class LocalDateTimeRequest {
+        private LocalDateTime localDateTimeValue;
+
+        public LocalDateTime getLocalDateTimeValue() {
+            return localDateTimeValue;
+        }
+
+    }
+}

--- a/specmock/src/test/java/io/specmock/core/ObjectMapperTest.java
+++ b/specmock/src/test/java/io/specmock/core/ObjectMapperTest.java
@@ -1,21 +1,38 @@
 package io.specmock.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
+/*
+ * Copyright 2023 SpecMock
+ * (c) 2023 SpecMock Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 class ObjectMapperTest {
 
     private ObjectMapper objectMapper;
-    private String value = "{\"localDateTimeValue\":\"2020-01-01T00:00:00\"}";
+    private static final String value = "{\"localDateTimeValue\":\"2020-01-01T00:00:00\"}";
 
     @BeforeEach
     void setUp() {
@@ -33,12 +50,13 @@ class ObjectMapperTest {
     void supportLocalDateTime() throws JsonProcessingException {
         objectMapper.registerModule(new JavaTimeModule());
 
-        final LocalDateTimeRequest localDateTimeRequest = objectMapper.readValue(value, LocalDateTimeRequest.class);
+        final LocalDateTimeRequest localDateTimeRequest = objectMapper.readValue(
+                value, LocalDateTimeRequest.class);
 
-        final LocalDateTime expected = LocalDateTime.of(2020, 1, 1, 0, 0, 0);
+        final LocalDateTime expected = LocalDateTime.of(
+                2020, 1, 1, 0, 0, 0);
         assertThat(localDateTimeRequest.getLocalDateTimeValue()).isEqualTo(expected);
     }
-
 
     private static class LocalDateTimeRequest {
         private LocalDateTime localDateTimeValue;
@@ -46,6 +64,5 @@ class ObjectMapperTest {
         public LocalDateTime getLocalDateTimeValue() {
             return localDateTimeValue;
         }
-
     }
 }


### PR DESCRIPTION
## Motivation:
- I confirmed that an exception occurs when deserializing LocalDateTime.

## Modifications:
- Added dependency implementation com.fasterxml.jackson.datatype:jackson-datatype-jsr310.
- Added JavaTimeModule registration to ObjectMapper for improved serialization and deserialization of Java 8 date and time types.

## Results:
- This change ensures better support for Java 8 date/time API in JSON processing.